### PR TITLE
Allow for `channelTypes` for the `"CHANNEL"` option type

### DIFF
--- a/playground/src/commands/channel-types.ts
+++ b/playground/src/commands/channel-types.ts
@@ -1,27 +1,31 @@
 import type { Gatekeeper } from "@itsmapleleaf/gatekeeper/src/main"
-import { createSecretKey } from "crypto"
 
 export default function defineCommands(gatekeeper: Gatekeeper) {
   gatekeeper.addSlashCommand({
     name: "channel-types",
     description: "Test channel types",
     options: {
-      text: {
+      "text": {
         type: "CHANNEL",
         description: "A text channel",
         channelTypes: ["GUILD_TEXT"],
       },
-      voice: {
+      "voice": {
         type: "CHANNEL",
         description: "A voice channel",
         channelTypes: ["GUILD_VOICE"],
       },
-      category: {
+      "text-voice": {
+        type: "CHANNEL",
+        description: "A voice channel",
+        channelTypes: ["GUILD_TEXT", "GUILD_VOICE"],
+      },
+      "category": {
         type: "CHANNEL",
         description: "A category",
         channelTypes: ["GUILD_CATEGORY"],
       },
-      any: {
+      "any": {
         type: "CHANNEL",
         description: "Any channel",
       },

--- a/playground/src/commands/channel-types.ts
+++ b/playground/src/commands/channel-types.ts
@@ -1,0 +1,42 @@
+import type { Gatekeeper } from "@itsmapleleaf/gatekeeper/src/main"
+import { createSecretKey } from "crypto"
+
+export default function defineCommands(gatekeeper: Gatekeeper) {
+  gatekeeper.addSlashCommand({
+    name: "channel-types",
+    description: "Test channel types",
+    options: {
+      text: {
+        type: "CHANNEL",
+        description: "A text channel",
+        channelTypes: ["GUILD_TEXT"],
+      },
+      voice: {
+        type: "CHANNEL",
+        description: "A voice channel",
+        channelTypes: ["GUILD_VOICE"],
+      },
+      category: {
+        type: "CHANNEL",
+        description: "A category",
+        channelTypes: ["GUILD_CATEGORY"],
+      },
+      any: {
+        type: "CHANNEL",
+        description: "Any channel",
+      },
+    },
+    run(context) {
+      const { any, category, text, voice } = context.options
+
+      const selection = [
+        any?.name,
+        category?.name,
+        text?.name,
+        voice?.name,
+      ].filter((s) => !!s)
+
+      context.reply(() => `You selected ${selection}`)
+    },
+  })
+}

--- a/playground/src/commands/channel-types.ts
+++ b/playground/src/commands/channel-types.ts
@@ -18,7 +18,7 @@ export default function defineCommands(gatekeeper: Gatekeeper) {
       "text-voice": {
         type: "CHANNEL",
         description: "A voice channel",
-        channelTypes: ["GUILD_TEXT", "GUILD_VOICE"],
+        channelTypes: ["GUILD_VOICE", "GUILD_TEXT"],
       },
       "category": {
         type: "CHANNEL",

--- a/src/core/command/slash-command.ts
+++ b/src/core/command/slash-command.ts
@@ -203,7 +203,6 @@ export type SlashCommandOptionConfigBase = {
   required?: boolean
 }
 
-// I don't know where to put this, help
 /** Sorts channel types based on Discord's list */
 function sortChannelTypes(
   arrA: SlashCommandOptionChannelType[],

--- a/src/core/command/slash-command.ts
+++ b/src/core/command/slash-command.ts
@@ -203,6 +203,29 @@ export type SlashCommandOptionConfigBase = {
   required?: boolean
 }
 
+// I don't know where to put this, help
+/** Sorts channel types based on Discord's list */
+function sortChannelTypes(
+  arrA: SlashCommandOptionChannelType[],
+): SlashCommandOptionChannelType[] {
+  const channelTypesOrder = [
+    "GUILD_TEXT",
+    "DM",
+    "GUILD_VOICE",
+    "GROUP_DM",
+    "GUILD_CATEGORY",
+    "GUILD_NEWS",
+    "GUILD_STORE",
+    "GUILD_NEWS_THREAD",
+    "GUILD_PUBLIC_THREAD",
+    "GUILD_PRIVATE_THREAD",
+    "GUILD_STAGE_VOICE",
+  ]
+  return [...arrA].sort(
+    (a, b) => channelTypesOrder.indexOf(a) - channelTypesOrder.indexOf(b),
+  )
+}
+
 export function defineSlashCommand<Options extends SlashCommandOptionConfigMap>(
   config: SlashCommandConfig<Options>,
 ): Command {
@@ -220,8 +243,11 @@ export function defineSlashCommand<Options extends SlashCommandOptionConfigMap>(
     // so normalize undefined to an empty array
     choices: ("choices" in option && option.choices) || [],
 
+    // Discord returns channel types in a specific order
     channelTypes:
-      ("channelTypes" in option && option.channelTypes) || undefined,
+      ("channelTypes" in option &&
+        sortChannelTypes(option.channelTypes ?? [])) ||
+      undefined,
   }))
 
   const commandData: ApplicationCommandData = {

--- a/src/core/command/slash-command.ts
+++ b/src/core/command/slash-command.ts
@@ -70,10 +70,29 @@ export type SlashCommandOptionConfig = SlashCommandOptionConfigBase &
       }
     | { type: "BOOLEAN" }
     | { type: "USER" }
-    | { type: "CHANNEL" }
+    | {
+        type: "CHANNEL"
+        channelTypes?: SlashCommandOptionChannelType[]
+      }
     | { type: "ROLE" }
     | { type: "MENTIONABLE" }
   )
+
+/**
+ * All possible channel types to filter by when using the `CHANNEL` option type
+ */
+export type SlashCommandOptionChannelType =
+  | "GUILD_TEXT"
+  | "DM"
+  | "GUILD_VOICE"
+  | "GROUP_DM"
+  | "GUILD_CATEGORY"
+  | "GUILD_NEWS"
+  | "GUILD_STORE"
+  | "GUILD_NEWS_THREAD"
+  | "GUILD_PUBLIC_THREAD"
+  | "GUILD_PRIVATE_THREAD"
+  | "GUILD_STAGE_VOICE"
 
 /**
  * A potential choice for a slash command option
@@ -198,6 +217,8 @@ export function defineSlashCommand<Options extends SlashCommandOptionConfigMap>(
     // discord returns undefined if the user passed an empty array,
     // so normalize undefined to an empty array
     choices: ("choices" in option && option.choices) || [],
+
+    channelType: ("channelTypes" in option && option.channelTypes) || undefined,
   }))
 
   const commandData: ApplicationCommandData = {
@@ -222,6 +243,8 @@ export function defineSlashCommand<Options extends SlashCommandOptionConfigMap>(
           type: option.type,
           required: option.required,
           choices: ("choices" in option && option.choices) || [],
+          channelType:
+            ("channelTypes" in option && option.channelTypes) || undefined,
         })),
       }
 


### PR DESCRIPTION
Slash command Channel options allow to filter possible channels by type, this PR implements that to `addSlashCommand` config. Also included a demo `/channel-types` command to the playground.

~~Command diffing does not work properly for commands that have options with a channel type filter, making it recreate them every boot. Working to fix that~~ Diffing works properly now!